### PR TITLE
Allow boxes to be selected using an env var.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
-#VM boxes
+# VM boxes
 .vagrant
+
+# Editor config/s
+.vscode

--- a/README.md
+++ b/README.md
@@ -31,6 +31,10 @@ Virtualbox is used by vagrant to spin up the VM
 - Run `vagrant suspend` to stop the running VM, saving the current state (will resume from here on next `vagrant up`)
 - Run `vagrant destroy` to remove the VM (useful if the VM needs spinning up from scratch again)
 
+# Choosing a VM
+A list of available VMs can be viewed in `./vmList.rb`. These can be used be setting the `BOX_NAME` env var to one of the 'keys' (the strings on the left of the list).
+- Check the correct one is available / running with the `vagrant status` command
+
 ## Accessing shared folders
 note - This only needs to be done once, when initialising the VM (e.g. first time using it, or after a `vagrant destroy`)
 - Run `vagrant up`

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,26 +1,27 @@
 # -*- mode: ruby -*-
 # vi: set ft=ruby :
 
-# Box name defaults to win7-ie11, use an env var to use different boxes
-box_name = box_name = ENV['box_name'] != nil ? ENV['box_name'].strip : 'win7-ie11'
+require_relative "vmList"
+include VMList
 
-# Box repo defaults to http://aka.ms (where modern.ie boxes are stored). Set env var to override
-box_repo = ENV['box_repo'] != nil ? ENV['box_repo'].strip : 'http://aka.ms'
-
+# Env Variables
+# Override box to use - default is "win7-ie11"
+BOX_NAME = ENV["BOX_NAME"] != nil ? ENV["BOX_NAME"].strip : "win7-ie11"
+# Override box download location - default http://aka.ms (where modern.ie boxes are stored).
+BOX_REPO = ENV["BOX_REPO"] != nil ? ENV["BOX_REPO"].strip : "http://aka.ms"
 # Env variable for users choosing to RDP into the vm - toggles whether gui should be displayed by virtualbox
-vm_gui = ENV['vm_gui'] == 'false' ? false : true
+BOX_GUI = ENV["BOX_GUI"] == "false" ? false : true
 
 Vagrant.configure("2") do |config|
-  ## Box
-
   # If the box is win7-ie11, the convention for the box name is modern.ie/win7-ie11
-  config.vm.box = "modern.ie/" + box_name
+  config.vm.box = "modern.ie-" + BOX_NAME
 
   # If the box is win7-ie11, the convention for the box url is http://aka.ms/vagrant-win7-ie11
-  config.vm.box_url = box_repo + "/vagrant-" + box_name
+  config.vm.box_url = BOX_REPO + BOXES[BOX_NAME]
 
   ## System
-  config.vm.guest= :windows
+  config.vm.define BOX_NAME
+  config.vm.guest = :windows
   config.vm.boot_timeout = 500
 
   ## Shared Folders
@@ -37,10 +38,11 @@ Vagrant.configure("2") do |config|
 
   config.vm.provider "virtualbox" do |vb|
     # Display the VirtualBox GUI when booting the machine
-    vb.gui = vm_gui
+    vb.gui = BOX_GUI
+    vb.name = BOX_NAME
     vb.customize ["modifyvm", :id, "--memory", "1024"]
     vb.customize ["modifyvm", :id, "--vram", "128"]
-    vb.customize ["modifyvm", :id,  "--cpus", "2"]
+    vb.customize ["modifyvm", :id, "--cpus", "2"]
     vb.customize ["modifyvm", :id, "--natdnsproxy1", "on"]
     vb.customize ["modifyvm", :id, "--natdnshostresolver1", "on"]
     vb.customize ["guestproperty", "set", :id, "/VirtualBox/GuestAdd/VBoxService/--timesync-set-threshold", 10000]

--- a/vmList.rb
+++ b/vmList.rb
@@ -1,0 +1,15 @@
+module VMList
+  # Box names, keys are what user will add to env var, literal is used for download link
+  BOXES = {
+    "xp-ie6" => "vagrant-xp-ie6",
+    "xp-ie8" => "vagrant-xp-ie8",
+    "vista-ie7" => "vagrant-vista-ie7",
+    "win7-ie8" => "vagrant-win7-ie8",
+    "win7-ie9" => "vagrant-win7-ie9",
+    "win7-ie10" => "vagrant-win7-ie10",
+    "win7-ie11" => "vagrant-win7-ie11",
+    "win8-ie10" => "vagrant-win8-ie10",
+    "win81-ie11" => "vagrant-win81-ie11",
+    "win10-msedge" => "vagrant-win10-msedge",
+  }
+end


### PR DESCRIPTION
Allow user to set env var to select which VM box they want. 

This list is controlled unlike the previous method that assumed the user knew the correct string to use.

There is still some enhancements to make it so the user doesn't have to actually look in the vmList.rb file, but for the time being it works pretty well.