### PR TITLE
Updated download locations to MS's new format

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -7,16 +7,16 @@ include VMList
 # Env Variables
 # Override box to use - default is "win7-ie11"
 BOX_NAME ||= ENV["BOX_NAME"] != nil ? ENV["BOX_NAME"].strip : "win7-ie11"
-# Override box download location - default http://aka.ms (where modern.ie boxes are stored).
-BOX_REPO ||= ENV["BOX_REPO"] != nil ? ENV["BOX_REPO"].strip : "http://aka.ms"
+# Override box download location - default http://aka.ms/ (where modern.ie boxes are stored).
+BOX_REPO ||= ENV["BOX_REPO"] != nil ? ENV["BOX_REPO"].strip : "http://aka.ms/"
 # Env variable for users choosing to RDP into the vm - toggles whether gui should be displayed by virtualbox
 BOX_GUI ||= ENV["BOX_GUI"] == "false" ? false : true
 
 Vagrant.configure("2") do |config|
-  # If the box is win7-ie11, the convention for the box name is modern.ie/win7-ie11
+  # If the box is win7-ie11, the convention for the box name is modern.ie-win7-ie11
   config.vm.box = "modern.ie-" + BOX_NAME
 
-  # If the box is win7-ie11, the convention for the box url is http://aka.ms/vagrant-win7-ie11
+  # If the box is win7-ie11, the convention for the box url is http://aka.ms/ie11.win7.vagrant
   config.vm.box_url = BOX_REPO + BOXES[BOX_NAME]
 
   ## System

--- a/vmList.rb
+++ b/vmList.rb
@@ -1,15 +1,15 @@
 module VMList
   # Box names, keys are what user will add to env var, literal is used for download link
   BOXES ||= {
-    "xp-ie6" => "vagrant-xp-ie6",
-    "xp-ie8" => "vagrant-xp-ie8",
-    "vista-ie7" => "vagrant-vista-ie7",
-    "win7-ie8" => "vagrant-win7-ie8",
-    "win7-ie9" => "vagrant-win7-ie9",
-    "win7-ie10" => "vagrant-win7-ie10",
-    "win7-ie11" => "vagrant-win7-ie11",
-    "win8-ie10" => "vagrant-win8-ie10",
-    "win81-ie11" => "vagrant-win81-ie11",
-    "win10-msedge" => "vagrant-win10-msedge",
+    "xp-ie6" => "ie6.xp.vagrant",
+    "xp-ie8" => "ie8.xp.vagrant",
+    "vista-ie7" => "ie7.vista.vagrant",
+    "win7-ie8" => "ie8.win7.vagrant",
+    "win7-ie9" => "ie9.win7.vagrant",
+    "win7-ie10" => "ie10.win7.vagrant",
+    "win7-ie11" => "ie11.win7.vagrant",
+    "win8-ie10" => "ie10.win8.vagrant",
+    "win81-ie11" => "ie11.win81.vagrant",
+    "win10-msedge" => "msedge.win10.vagrant",
   }
 end


### PR DESCRIPTION
Fixes #5 

### Cause
Microsoft updated the download locations of their Windows vagrant boxes, causing the old configuration to break.

### Fix
- Updated the URLs resolved via. the `vmlist` object.
- Updated comments in the `Vagrantfile`

### Misc
- Shoutout to [this gist](https://gist.github.com/anthonysterling/7cb85670b36821122a4a#gistcomment-2356756) which documented the new URLs